### PR TITLE
empty files line endings #461

### DIFF
--- a/PowerEditor/src/ScitillaComponent/Buffer.cpp
+++ b/PowerEditor/src/ScitillaComponent/Buffer.cpp
@@ -510,12 +510,10 @@ BufferID FileManager::loadFile(const TCHAR * filename, Document doc, int encodin
 			if (nullptr != UnicodeConvertor.getNewBuf()) 
 			{
 				int format = getEOLFormatForm(UnicodeConvertor.getNewBuf(), UnicodeConvertor.getNewSize());
-				buf->setFormat(format == -1?WIN_FORMAT:(formatType)format);
+				if( format != -1 )
+					buf->setFormat((formatType)format);
 			}
-			else
-			{
-				buf->setFormat(WIN_FORMAT);
-			}
+
 
 			UniMode um = UnicodeConvertor.getEncoding();
 			if (um == uni7Bit)
@@ -536,7 +534,8 @@ BufferID FileManager::loadFile(const TCHAR * filename, Document doc, int encodin
             // Test if encoding is set to UTF8 w/o BOM (usually for utf8 indicator of xml or html)
             buf->setEncoding((encoding == SC_CP_UTF8)?-1:encoding);
             buf->setUnicodeMode(uniCookie);
-			buf->setFormat(format);
+			if ( format != -1 )
+				buf->setFormat(format);
 		}
 
 		//determine buffer properties
@@ -569,18 +568,17 @@ bool FileManager::reloadBuffer(BufferID id)
 			if (nullptr != UnicodeConvertor.getNewBuf()) 
 			{
 				int format = getEOLFormatForm(UnicodeConvertor.getNewBuf(), UnicodeConvertor.getNewSize());
-				buf->setFormat(format == -1?WIN_FORMAT:(formatType)format);
+				if( format != -1 )
+					buf->setFormat((formatType)format);
 			}
-			else
-			{
-				buf->setFormat(WIN_FORMAT);
-			}
+
 			buf->setUnicodeMode(UnicodeConvertor.getEncoding());
 		}
 		else
 		{
 			buf->setEncoding(encoding);
-			buf->setFormat(format);
+			if ( format != - 1)
+				buf->setFormat(format);
 			buf->setUnicodeMode(uniCookie);
 		}
 	}
@@ -1264,7 +1262,7 @@ inline bool FileManager::loadFileData(Document doc, const TCHAR * filename, char
 
 	if (pFormat != NULL)
 	{
-		*pFormat = (format == -1)?WIN_FORMAT:(formatType)format;
+		*pFormat = (formatType)format;
 	}
 	_pscratchTilla->execute(SCI_EMPTYUNDOBUFFER);
 	_pscratchTilla->execute(SCI_SETSAVEPOINT);


### PR DESCRIPTION
when a user creates a new file, uses user preferences
however when opening an empty file where notepad++ can't detect the line endings, it uses windows line endings

I've proposed a coupe of changes. First noticing that on construction Buffer::_format is set to the users eol preference, theres no need for a default fallback to be set. 

1) FileManager::loadFileData sets *pFormat to -1 when it can't detect a line ending (empty file)
2) FileManager::loadFile and FileManager::ReloadBuffer only set the line ending of the buffer when format!=-1, thus uses the users preference
